### PR TITLE
HFP-4128 Fix re-creating state for user responses

### DIFF
--- a/js/summary.js
+++ b/js/summary.js
@@ -182,7 +182,12 @@ H5P.Summary = (function ($, Question, XApiEventBuilder, StopWatch) {
         that.dataBitMap[panelIndex] = this.dataBitMap[panelIndex] || [];
         that.dataBitMap[panelIndex][id] = summaryIndex;
 
-        emptyEntriesCount = that.dataBitMap[panelIndex].length - (that.dataBitMap[panelIndex].filter(function () { return true; })).length;
+        const filledEntriesCount = (
+          that.dataBitMap[panelIndex].filter(function () {
+            return true; // dataBitMap[panelIndex] can contain "empty" values
+          })
+        ).length;
+        emptyEntriesCount = that.dataBitMap[panelIndex].length - filledEntriesCount;
 
         // checks the answer and updates the user response array
         if(that.answers[panelIndex] && (that.answers[panelIndex].indexOf(id) !== -1)){


### PR DESCRIPTION
As reported and discussed in https://github.com/h5p/moodle-mod_hvp/issues/442, _Summary_ does not re-create the previous state properly - the visual score is correct, but the score that `getScore` reports is wrong.

When merged in, this bug will be fixed: will re-create the `userResponses` variable correctly, so `getScore` reports the correct score.