### PR TITLE
HFP-4137 Add completion/succes flags

### DIFF
--- a/js/summary.js
+++ b/js/summary.js
@@ -391,7 +391,9 @@ H5P.Summary = (function ($, Question, XApiEventBuilder, StopWatch) {
 
       // Trigger overall answered xAPI event when finished
       if (finished) {
-        that.triggerXAPIScored(that.getScore(), that.getMaxScore(), 'answered');
+        that.triggerXAPIScored(
+          that.getScore(), that.getMaxScore(), 'answered', true, that.getScore() === that.getMaxScore()
+        );
       }
     };
 
@@ -795,6 +797,8 @@ H5P.Summary = (function ($, Question, XApiEventBuilder, StopWatch) {
     var result = XApiEventBuilder.createResult()
       .response(userAnswer.join('[,]'))
       .duration(duration)
+      .completion(true)
+      .success(self.correctOnFirstTry(userAnswer))
       .score((self.correctOnFirstTry(userAnswer) ? 1 : 0), 1)
       .build();
 
@@ -833,6 +837,8 @@ H5P.Summary = (function ($, Question, XApiEventBuilder, StopWatch) {
     var result = XApiEventBuilder.createResult()
       .score(self.getScore(), self.getMaxScore())
       .duration(self.getTotalPassedTime())
+      .completion(true)
+      .success(self.getScore() === self.getMaxScore())
       .build();
 
     // creates the definition object


### PR DESCRIPTION
When merged in, will ensure that all xAPI statements that bear a result also carry the proper completion/success flag.